### PR TITLE
fixed insertRule() method error

### DIFF
--- a/index.js
+++ b/index.js
@@ -467,7 +467,12 @@
                     'from { width:' + Trex.config.WIDTH + 'px }' +
                     'to { width: ' + this.dimensions.WIDTH + 'px }' +
                     '}';
-                document.styleSheets[0].insertRule(keyframes, 0);
+                
+                // create a style sheet to put the keyframe rule in 
+                // and then place the style sheet in the html head    
+                var sheet = document.createElement('style');
+                sheet.innerHTML = keyframes;
+                document.head.appendChild(sheet);
 
                 this.containerEl.addEventListener(Runner.events.ANIM_END,
                     this.startGame.bind(this));


### PR DESCRIPTION
For some reason, the insertRule() method used in the playIntro function wasn't working. My guess is that because it has a return value now (it must have changed recently), the code would exit out and never finish the rest of the playIntro() method. My code avoids the insertRule() method by creating a new style sheet, placing the keyframes rule in it, and then putting that stylesheet in the header of the index.html document. This seems to me to be in line with the original code, but in a way that functions properly. Let me know if you have any suggestions or different ways we can go about fixing this problem.